### PR TITLE
Add copy, assignment constructors to sndScifiHit

### DIFF
--- a/shipLHC/sndScifiHit.h
+++ b/shipLHC/sndScifiHit.h
@@ -12,7 +12,10 @@ class sndScifiHit : public SndlhcHit
 
     /** Default constructor **/
     sndScifiHit();
-    sndScifiHit(Int_t detID);
+    /** Copy constructor **/
+    sndScifiHit(const sndScifiHit& hit) = default;
+    sndScifiHit& operator=(const sndScifiHit& hit) = default;
+    explicit sndScifiHit(Int_t detID);
     //  Constructor from ScifiPoint
     sndScifiHit(int detID,std::vector<ScifiPoint*>,std::vector<Float_t>);
 
@@ -39,15 +42,12 @@ class sndScifiHit : public SndlhcHit
 	1 SiPM channel has 104 pixels, pixel can only see 0 or >0 photons.
 */
   private:
-    /** Copy constructor **/
-    sndScifiHit(const sndScifiHit& hit);
-    sndScifiHit operator=(const sndScifiHit& hit);
     Float_t ly_loss(Float_t distance);
     Float_t sipm_saturation(Float_t ly, Float_t nphe_max);
     Float_t npix_to_qdc(Float_t npix);
     Float_t flag;   ///< flag
 
-    ClassDef(sndScifiHit,4);
+    ClassDef(sndScifiHit, 4);
 
 };
 


### PR DESCRIPTION
Also makes conversion from int explicit to avoid silent bugs.

Required for my solution to https://github.com/SND-LHC/sndsw/pull/211 memory leaks